### PR TITLE
Set up some basic IAM using Terraform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+Project 1/Terraform/.terraform/plugins/windows_amd64/lock.json
+Project 1/Terraform/.terraform/plugins/windows_amd64/terraform-provider-aws_v1.35.0_x4.exe
+Project 1/Terraform/terraform.tfstate
+Project 1/Terraform/terraform.tfstate.backup

--- a/Project 1/Terraform/Main.tf
+++ b/Project 1/Terraform/Main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  region     = "us-west-1"
+}
+
+resource "aws_iam_group" "Eat-Team" {
+  name = "EAT-Team"
+}
+
+resource "aws_iam_user" "Alex"{
+  name = "Alex"
+}
+
+resource "aws_iam_user" "Erik"{
+  name = "Erik"
+}
+
+resource "aws_iam_user" "TK"{
+  name = "TK"
+}
+
+resource "aws_iam_user" "Brian"{
+  name = "Brian"
+}
+
+resource "aws_iam_group_membership" "EAT-Membership" {
+  name = "Adding-members-to-EAT"
+
+  users = [
+    "${aws_iam_user.Alex.name}",
+    "${aws_iam_user.Erik.name}",
+	"${aws_iam_user.Brian.name}",
+	"${aws_iam_user.TK.name}",
+  ]
+
+  group = "${aws_iam_group.Eat-Team.name}"
+}
+
+data "aws_iam_policy" "policy" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "attach-policy" {
+  group = "${aws_iam_group.Eat-Team.name}"
+  policy_arn = "${data.aws_iam_policy.policy.arn}"
+}


### PR DESCRIPTION
Creating 4 users with terraform, a group, policy (and attaching the policy). Accounts need to generate a new password manually. They are added to the group automatically, which has administrator access, but it is not possible to log into the accounts.

As of 4/2017 it isn't reccomended to store tfstate files in version control per here :

https://github.com/hashicorp/terraform/issues/13891

It is also reccomended not to store the .terraform folder into version control per here :

https://www.terraform.io/docs/commands/get.html

These should be put in the S3 bucket instead.