### PR TITLE
Certs, auto route 53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Project 1/Terraform/terraform.tfstate.backup
 Project 1/Terraform/.terraform.tfstate.lock.info
 Project 1/Terraform/.terraform/plugins/windows_amd64/terraform-provider-aws_v1.36.0_x4.exe
 *.tfstate
+Project 1/Terraform/.terraform/plugins/windows_amd64/terraform-provider-aws_v1.37.0_x4.exe


### PR DESCRIPTION
Also removed the https group, because the ALB will now decrypt (hopefully) then forward the traffic onto port 80 of the blog servers. Route 53 for the certs should now be done automatically instead of manually having to go to the certificate.